### PR TITLE
Add 201 as successful HTTP status on register.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,6 +85,7 @@
     url: '{{ (item.api_url | d(gitlab_runner__api_url)) + "/api/v1/runners/register.json" }}'
     method: 'POST'
     body: 'token={{ item.token | d(gitlab_runner__token) }}&description={{ item.name | urlencode }}&tag_list={{ ((item.tags|d([]) + gitlab_runner__default_tags + gitlab_runner__tags + gitlab_runner__group_tags + gitlab_runner__host_tags) | unique | join(",")) | urlencode }}'
+    status_code: '200,201'
   register: gitlab_runner__register_new_instances
   with_flattened:
     - '{{ gitlab_runner__default_instances }}'


### PR DESCRIPTION
/api/v1/runners/register.json returns 201 on success.
