### PR TITLE
Add variable to set "running untagged job flag" while registering runner.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -538,5 +538,11 @@ gitlab_runner__cache_bucket_location: ''
 # Enable or disable connections to the S3 service over HTTP instead of HTTPS.
 gitlab_runner__cache_insecure: False
                                                                    # ]]]
+
+# .. envvar:: gitlab_runner__run_untagged [[[
+#
+# Enable or disable running untagged jobs.
+gitlab_runner__run_untagged: True
+                                                                   # ]]]
                                                                    # ]]]
                                                                    # ]]]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,7 +84,7 @@
   uri:
     url: '{{ (item.api_url | d(gitlab_runner__api_url)) + "/api/v1/runners/register.json" }}'
     method: 'POST'
-    body: 'token={{ item.token | d(gitlab_runner__token) }}&description={{ item.name | urlencode }}&tag_list={{ ((item.tags|d([]) + gitlab_runner__default_tags + gitlab_runner__tags + gitlab_runner__group_tags + gitlab_runner__host_tags) | unique | join(",")) | urlencode }}'
+    body: 'token={{ item.token | d(gitlab_runner__token) }}&description={{ item.name | urlencode }}&tag_list={{ ((item.tags|d([]) + gitlab_runner__default_tags + gitlab_runner__tags + gitlab_runner__group_tags + gitlab_runner__host_tags) | unique | join(",")) | urlencode }}&run_untagged={{ gitlab_runner__run_untagged }}'
     status_code: '200,201'
   register: gitlab_runner__register_new_instances
   with_flattened:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -97,7 +97,8 @@
          (item.state is undefined or item.state != 'absent') and
          (ansible_local|d(True) and
           (ansible_local.gitlab_runner is undefined or
-           item.name not in ansible_local.gitlab_runner.instances)))
+           item.name not in ansible_local.gitlab_runner.instances)) and
+        (gitlab_runner__run_untagged|d()))
 
 - name: Generate gitlab-runner configuration file
   template:


### PR DESCRIPTION
Added by https://gitlab.com/gitlab-org/gitlab-ci-multi-runner/merge_requests/438

Default value : True.
Usefull when you have runner with tags.