### PR TITLE
Update cache before install

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,6 +44,7 @@
   apt:
     name: '{{ item }}'
     state: 'present'
+    update_cache: True
     install_recommends: False
   with_items: [ 'apt-transport-https', 'openssl', 'ca-certificates' ]
 


### PR DESCRIPTION
Avoid this error

`TASK [gitlab_runner : Make sure APT can access HTTPS repositories] *************                                                                                                
failed: [runner_ovh] (item=[u'apt-transport-https', u'openssl', u'ca-certificates']) => {"failed": true, "item": ["apt-transport-https", "openssl", "ca-certificates"], "msg": "
No package matching 'apt-transport-https' is available"}    `