### PR TITLE
Fix permissions of ~/.ssh directory

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -143,7 +143,7 @@
     state: 'directory'
     owner: '{{ gitlab_runner__user }}'
     group: '{{ gitlab_runner__group }}'
-    mode: '0600'
+    mode: '0700'
   when: gitlab_runner__ssh_known_hosts
 
 - name: Make sure the ~/.ssh/known_hosts file exists


### PR DESCRIPTION
The directory needs the execute permission, otherwise the SSH client is
unable to load keys, known hosts, etc.