### PR TITLE
Update APT repo GPG key

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,7 @@ gitlab_runner__apt_upstream: True
 # .. envvar:: gitlab_runner__apt_key [[[
 #
 # GPG key which signs the upstream APT repository package list.
-gitlab_runner__apt_key: '1A4C919DB987D435939638B914219A96E15E78F4'
+gitlab_runner__apt_key: 'F6403F6544A38863DAA0B6E03F01618A51312F3F'
 
                                                                    # ]]]
 # .. envvar:: gitlab_runner__apt_repo [[[


### PR DESCRIPTION
See: https://about.gitlab.com/releases/2020/03/30/gpg-key-for-gitlab-package-repositories-metadata-changing/